### PR TITLE
Fix main method visibility in AssetServiceApplication

### DIFF
--- a/vehicle-tracker-backend/asset-service/src/main/java/com/github/diogocerqueiralima/asset/service/AssetServiceApplication.java
+++ b/vehicle-tracker-backend/asset-service/src/main/java/com/github/diogocerqueiralima/asset/service/AssetServiceApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class AssetServiceApplication {
 
-    static void main(String[] args) {
+    public static void main(String[] args) {
         SpringApplication.run(AssetServiceApplication.class, args);
     }
 


### PR DESCRIPTION
## Summary
Fixed the visibility modifier of the `main` method in `AssetServiceApplication` from package-private to public, ensuring it can be properly invoked by the Spring Boot framework.

## Key Changes
- Changed `main` method signature from `static void main(String[] args)` to `public static void main(String[] args)` in `AssetServiceApplication`

## Implementation Details
The `main` method is the entry point for the Spring Boot application and must be declared as `public` to be accessible by the JVM when launching the application. The previous package-private visibility would prevent proper application startup.

https://claude.ai/code/session_01W9RhdBHri3TBef6p4zR6GS